### PR TITLE
Update orbits.py to accept ObjID as alternate column name

### DIFF
--- a/oif/orbits.py
+++ b/oif/orbits.py
@@ -269,7 +269,7 @@ class Orbits(object):
         # that might need remapping from the on-file values to our standardized values.
         altNames = {}
         altNames['objId'] = ['objId', 'objid', '!!ObjID', '!!OID', '!!S3MID', 'OID', 'S3MID'
-                             'objid(int)', 'full_name', '#name']
+                             'objid(int)', 'full_name', '#name', 'ObjID']
         altNames['q'] = ['q']
         altNames['a'] = ['a']
         altNames['e'] = ['e', 'ecc']


### PR DESCRIPTION
In order to facilitate standardisation of column names across OIF+SSPP input and output, I've changed orbits.py to accept 'ObjID' as a valid alternate column name. :)